### PR TITLE
fix(discover): keep recipe feed global for signed-in users

### DIFF
--- a/src/components/RecipeBuilder.tsx
+++ b/src/components/RecipeBuilder.tsx
@@ -270,7 +270,7 @@ const RecipeBuilder: React.FC<RecipeBuilderProps> = ({
 
     try {
       const { data, errors } = await client.models.Recipe.list({
-        authMode: isAuthenticated ? 'userPool' : 'identityPool',
+        authMode: 'identityPool',
       });
 
       if (errors?.length) {
@@ -308,7 +308,7 @@ const RecipeBuilder: React.FC<RecipeBuilderProps> = ({
     } finally {
       setIsLoadingFeed(false);
     }
-  }, [isAuthenticated]);
+  }, []);
 
   useEffect(() => {
     loadRecipes();


### PR DESCRIPTION
## Summary
- keep Discover recipe loading on public auth mode so signed-in users still see all published recipes
- preserve `My recipes` filtering behavior to scope results to the current user only when that tag is selected
- remove the unnecessary `isAuthenticated` dependency from the recipe feed loader callback