### PR TITLE
fix(auth): allow signed-in users to read discover recipes

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -19,6 +19,7 @@ const schema = a.schema({
     })
     .authorization((allow) => [
       allow.ownerDefinedIn('ownerId'),
+      allow.authenticated().to(['read']),
       allow.guest().to(['read']),
     ]),
 

--- a/src/components/RecipeBuilder.tsx
+++ b/src/components/RecipeBuilder.tsx
@@ -270,7 +270,7 @@ const RecipeBuilder: React.FC<RecipeBuilderProps> = ({
 
     try {
       const { data, errors } = await client.models.Recipe.list({
-        authMode: 'identityPool',
+        authMode: isAuthenticated ? 'userPool' : 'identityPool',
       });
 
       if (errors?.length) {
@@ -308,7 +308,7 @@ const RecipeBuilder: React.FC<RecipeBuilderProps> = ({
     } finally {
       setIsLoadingFeed(false);
     }
-  }, []);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     loadRecipes();


### PR DESCRIPTION
## Summary
- add authenticated read access for `Recipe` records so signed-in users can still read community recipes
- keep guest read access intact for signed-out discovery
- preserve `My recipes` behavior by continuing to scope owner-only filtering to that specific tag