### PR TITLE
fix: make sandbox deployment work on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Recipes now include a `utensils` field (array of strings) for kitchen tools need
 - On bootstrap, `src/main.tsx` reads `outputs.custom.CloudFrontDomain` from `amplify_outputs.json` and stores it via `setCloudFrontDomain()` in `src/amplifyConfig.ts`
 - `getRecipeImageSource` in `RecipeBuilder.tsx` reads it dynamically at image-resolution time via `getCloudFrontDomain()`, falling back to `VITE_CLOUDFRONT_DOMAIN` env var
 - No env var needed after `npx ampx sandbox deploy` — the domain is auto-detected from the outputs
+- Sandbox deploy scripts in `scripts/` invoke the Amplify CLI through the installed JavaScript entrypoint, which keeps `npm run deploy:sandbox` working reliably across Windows, macOS, and Linux
 
 ## Agent checklist for every PR
 

--- a/scripts/deploy-sandbox.cjs
+++ b/scripts/deploy-sandbox.cjs
@@ -2,9 +2,10 @@ const { existsSync, readdirSync } = require('node:fs');
 const { join } = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { createHash } = require('node:crypto');
+const { resolveAmpxEntryPath } = require('./resolve-ampx-entry.cjs');
 
 const projectRoot = join(__dirname, '..');
-const ampxBin = join(projectRoot, 'node_modules', '.bin', 'ampx');
+const ampxEntryPoint = resolveAmpxEntryPath(projectRoot);
 const shim = join(__dirname, 'node-localstorage-shim.cjs');
 
 const findLtsNode = () => {
@@ -28,7 +29,7 @@ const result = spawnSync(
   [
     '--require',
     shim,
-    ampxBin,
+    ampxEntryPoint,
     'sandbox',
     '--once',
     '--outputs-out-dir',

--- a/scripts/destroy-sandbox.cjs
+++ b/scripts/destroy-sandbox.cjs
@@ -1,9 +1,10 @@
 const { existsSync, readdirSync } = require('node:fs');
 const { join } = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { resolveAmpxEntryPath } = require('./resolve-ampx-entry.cjs');
 
 const projectRoot = join(__dirname, '..');
-const ampxBin = join(projectRoot, 'node_modules', '.bin', 'ampx');
+const ampxEntryPoint = resolveAmpxEntryPath(projectRoot);
 const shim = join(__dirname, 'node-localstorage-shim.cjs');
 
 const findLtsNode = () => {
@@ -27,7 +28,7 @@ const result = spawnSync(
   [
     '--require',
     shim,
-    ampxBin,
+    ampxEntryPoint,
     'sandbox',
     'delete',
     '--yes',

--- a/scripts/resolve-ampx-entry.cjs
+++ b/scripts/resolve-ampx-entry.cjs
@@ -1,0 +1,27 @@
+const { existsSync, readFileSync } = require('node:fs');
+const { dirname, join } = require('node:path');
+
+const resolveAmpxEntryPath = (projectRoot) => {
+  try {
+    const packageJsonResolution = require.resolve(
+      '@aws-amplify/backend-cli/package.json',
+      { paths: [projectRoot] }
+    );
+    const packageJson = JSON.parse(readFileSync(packageJsonResolution, 'utf8'));
+    const binTarget = packageJson.bin?.ampx || packageJson.bin?.amplify;
+
+    if (binTarget) {
+      const resolvedEntryPoint = join(dirname(packageJsonResolution), binTarget);
+
+      if (existsSync(resolvedEntryPoint)) {
+        return resolvedEntryPoint;
+      }
+    }
+  } catch {
+    // Fall back to the local shim only if the package metadata cannot be resolved.
+  }
+
+  return join(projectRoot, 'node_modules', '.bin', 'ampx');
+};
+
+module.exports = { resolveAmpxEntryPath };

--- a/scripts/resolve-ampx-entry.test.cjs
+++ b/scripts/resolve-ampx-entry.test.cjs
@@ -1,0 +1,13 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { join } = require('node:path');
+
+const { resolveAmpxEntryPath } = require('./resolve-ampx-entry.cjs');
+
+test('resolveAmpxEntryPath resolves the Amplify CLI JavaScript entrypoint instead of the shell wrapper', () => {
+  const projectRoot = join(__dirname, '..');
+  const resolved = resolveAmpxEntryPath(projectRoot);
+
+  assert.match(resolved, /node_modules[\\/]@aws-amplify[\\/]backend-cli[\\/]lib[\\/]ampx\.js$/);
+  assert.doesNotMatch(resolved, /node_modules[\\/]\.bin[\\/]ampx$/);
+});


### PR DESCRIPTION
## Summary

Fixes `npm run deploy:sandbox` on Windows.

## Problem

The deployment script attempted to execute the Unix `.bin/ampx` shim directly. On Windows, this caused Node.js to interpret the shell wrapper as JavaScript, resulting in a syntax error before Amplify could start.

## Solution

Update the deployment script to invoke the actual Amplify CLI entry point in a cross-platform way.

## Result

- Linux/macOS behavior preserved
- Windows can now launch `ampx sandbox`
-  Remaining deployment errors are AWS credential configuration issues rather than script failures