### PR TITLE
Fix/cognito profile flicker

### DIFF
--- a/scripts/deploy-sandbox.cjs
+++ b/scripts/deploy-sandbox.cjs
@@ -31,7 +31,7 @@ const result = spawnSync(
     shim,
     ampxEntryPoint,
     'sandbox',
-    '--once'oooooooooooooooof,
+    '--once',
     '--outputs-out-dir',
     'public',
   ],

--- a/scripts/deploy-sandbox.cjs
+++ b/scripts/deploy-sandbox.cjs
@@ -31,7 +31,7 @@ const result = spawnSync(
     shim,
     ampxEntryPoint,
     'sandbox',
-    '--once',
+    '--once'oooooooooooooooof,
     '--outputs-out-dir',
     'public',
   ],

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,10 +3,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import App from './App';
 
-const { getCurrentUserMock, fetchUserAttributesMock, signOutMock } = vi.hoisted(() => ({
+const { getCurrentUserMock, fetchUserAttributesMock, signOutMock, recipeBuilderMock } = vi.hoisted(() => ({
   getCurrentUserMock: vi.fn(),
   fetchUserAttributesMock: vi.fn(),
   signOutMock: vi.fn(),
+  recipeBuilderMock: vi.fn(),
 }));
 
 vi.mock('aws-amplify/auth', async () => {
@@ -37,7 +38,10 @@ vi.mock('@aws-amplify/ui-react-core', () => ({
 }));
 
 vi.mock('./components/RecipeBuilder', () => ({
-  default: () => <div>RecipeBuilder</div>,
+  default: (props: any) => {
+    recipeBuilderMock(props);
+    return <div>RecipeBuilder</div>;
+  },
 }));
 
 vi.mock('./components/SignInForm', () => ({
@@ -48,6 +52,7 @@ describe('App auth initialization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
+    localStorage.clear();
   });
 
   it('does not render the unauthenticated experience before auth resolves', async () => {
@@ -64,5 +69,28 @@ describe('App auth initialization', () => {
 
     await waitFor(() => expect(screen.getByText('RecipeBuilder')).toBeInTheDocument());
     expect(screen.queryByText('Preparing your kitchen…')).not.toBeInTheDocument();
+  });
+
+  it('seeds the initial authenticated profile from persisted auth data', () => {
+    localStorage.setItem(
+      'arcaneKitchen.authState',
+      JSON.stringify({
+        isAuthenticated: true,
+        userId: 'user-1',
+        username: 'persisted-user',
+        email: 'persisted@example.com',
+      })
+    );
+
+    render(<App />);
+
+    const initialProps = recipeBuilderMock.mock.calls[0]?.[0];
+    expect(initialProps?.isAuthenticated).toBe(true);
+    expect(initialProps?.currentUser).toEqual(
+      expect.objectContaining({ username: 'persisted-user' })
+    );
+    expect(initialProps?.userAttributes).toEqual(
+      expect.objectContaining({ email: 'persisted@example.com' })
+    );
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,10 +296,23 @@ function AuthSuccess({ onComplete }: { onComplete: () => Promise<void> }) {
 function App() {
   const [authState, setAuthState] = useState<AuthState>(() => {
     const persisted = getPersistedAuthState();
+    const currentUser = persisted?.isAuthenticated
+      ? {
+          userId: persisted.userId,
+          username: persisted.username,
+        }
+      : null;
+    const userAttributes = persisted?.isAuthenticated
+      ? {
+          sub: persisted.userId ?? undefined,
+          email: persisted.email ?? undefined,
+        }
+      : null;
+
     return {
       isAuthenticated: persisted?.isAuthenticated ?? false,
-      currentUser: null,
-      userAttributes: null,
+      currentUser,
+      userAttributes,
       isInitialized: persisted !== null,
     };
   });


### PR DESCRIPTION
## Summary

Fixes a UI flicker that occurred when refreshing the application while already authenticated.

Previously, the application restored the authenticated shell immediately, but `currentUser` and `userAttributes` were still `null` until Cognito finished restoring the session. During that brief window, the header fell back to rendering **Guest Cook** before updating to the authenticated user's profile.

This change seeds the initial authenticated state from the existing persisted Cognito auth metadata while the normal Cognito verification continues in the background.

## Changes

- Seed `currentUser` from the persisted auth state during initialization.
- Seed `userAttributes` from the persisted auth state during initialization.
- Preserve the existing Cognito authentication flow.
- Keep Cognito as the source of truth.
- Add regression tests covering the initial authenticated render.

## Before
